### PR TITLE
Fix v4.5.0 release website link

### DIFF
--- a/_posts/2020s/2025-01-04-v450-released.md
+++ b/_posts/2020s/2025-01-04-v450-released.md
@@ -27,6 +27,6 @@ The most notable changes in this release are:
 
 No breaking configuration changes have been made since the v4.0.0 release. Please consult [the list of breaking changes](https://docs.inspircd.org/4/breaking-changes) if you are upgrading from v3.
 
-The full change log can be found [on the docs site](https://docs.inspircd.org/4/change-log/#inspircd-440) or [on GitHub](https://github.com/inspircd/inspircd/compare/v4.4.0...v4.5.0).
+The full change log can be found [on the docs site](https://docs.inspircd.org/4/change-log/#inspircd-450) or [on GitHub](https://github.com/inspircd/inspircd/compare/v4.4.0...v4.5.0).
 
 Please [consider supporting my development via GitHub Sponsors](https://github.com/sponsors/SadieCat/).


### PR DESCRIPTION
Point to the v4.5.0 release notes instead of v4.4.0.